### PR TITLE
fix duplicate doge avatar uuid

### DIFF
--- a/bundles/marketplace/doge_costume/doge_costume_avatar.json
+++ b/bundles/marketplace/doge_costume/doge_costume_avatar.json
@@ -1,6 +1,6 @@
 {
   "type": "AVATAR",
-  "id": "022f8260-f474-4577-bc4d-7978bf3b189b",
+  "id": "53990bd8-cf26-4229-9fb5-dca736cd988a",
   "name": "Flower Doge",
   "icon": "https://cdn.playhive.com/avatars/costume-doge.png",
   "bundle": "84b0cc99-fc17-4eef-8886-313c438954cc"


### PR DESCRIPTION
Fix an issue where the doge costume title and avatar had the same id.